### PR TITLE
Remove unused APIs in Diagnosis

### DIFF
--- a/api/v1/diagnosis_types.go
+++ b/api/v1/diagnosis_types.go
@@ -223,10 +223,6 @@ type JavaProfilerSpec struct {
 
 // DiagnosisStatus defines the observed state of Diagnosis.
 type DiagnosisStatus struct {
-	// Identifiable indicates if the diagnosis could be identified by the diagnoser chain.
-	Identifiable bool `json:"identifiable"`
-	// Recoverable indicates if the diagnosis could be recovered by the recoverer chain.
-	Recoverable bool `json:"recoverable"`
 	// Phase is a simple, high-level summary of where the diagnosis is in its lifecycle.
 	// The conditions array, the reason and message fields contain more detail about the
 	// pod's status.
@@ -247,23 +243,9 @@ type DiagnosisStatus struct {
 	// Conditions contains current service state of diagnosis.
 	// +optional
 	Conditions []DiagnosisCondition `json:"conditions,omitempty"`
-	// Message is a human readable message indicating details about why the diagnosis is in
-	// this condition.
-	// +optional
-	Message string `json:"message,omitempty"`
-	// Reason is a brief CamelCase message indicating details about why the diagnosis is in
-	// this state.
-	// +optional
-	Reason string `json:"reason,omitempty"`
 	// StartTime is RFC 3339 date and time at which the object was acknowledged by the system.
 	// +optional
 	StartTime metav1.Time `json:"startTime,omitempty"`
-	// Diagnoser indicates the diagnoser which has identified the diagnosis successfully.
-	// +optional
-	Diagnoser *NamespacedName `json:"diagnoser,omitempty"`
-	// Recoverer indicates the recoverer which has recovered the diagnosis successfully.
-	// +optional
-	Recoverer *NamespacedName `json:"recoverer,omitempty"`
 	// CommandExecutors is the list of command execution results.
 	// +optional
 	CommandExecutors []CommandExecutorStatus `json:"commandExecutors,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -429,16 +429,6 @@ func (in *DiagnosisStatus) DeepCopyInto(out *DiagnosisStatus) {
 		}
 	}
 	in.StartTime.DeepCopyInto(&out.StartTime)
-	if in.Diagnoser != nil {
-		in, out := &in.Diagnoser, &out.Diagnoser
-		*out = new(NamespacedName)
-		**out = **in
-	}
-	if in.Recoverer != nil {
-		in, out := &in.Recoverer, &out.Recoverer
-		*out = new(NamespacedName)
-		**out = **in
-	}
 	if in.CommandExecutors != nil {
 		in, out := &in.CommandExecutors, &out.CommandExecutors
 		*out = make([]CommandExecutorStatus, len(*in))

--- a/config/crd/bases/diagnosis.netease.com_diagnoses.yaml
+++ b/config/crd/bases/diagnosis.netease.com_diagnoses.yaml
@@ -490,29 +490,6 @@ spec:
                 to be user-facing content and display instructions. This field may
                 contain customized values for custom source.
               type: object
-            diagnoser:
-              description: Diagnoser indicates the diagnoser which has identified
-                the diagnosis successfully.
-              properties:
-                name:
-                  description: Name specifies the name of a kubernetes api resource.
-                  type: string
-                namespace:
-                  description: Namespace specifies the namespace of a kubernetes api
-                    resource.
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
-            identifiable:
-              description: Identifiable indicates if the diagnosis could be identified
-                by the diagnoser chain.
-              type: boolean
-            message:
-              description: Message is a human readable message indicating details
-                about why the diagnosis is in this condition.
-              type: string
             phase:
               description: "Phase is a simple, high-level summary of where the diagnosis
                 is in its lifecycle. The conditions array, the reason and message
@@ -558,37 +535,11 @@ spec:
                 - type
                 type: object
               type: array
-            reason:
-              description: Reason is a brief CamelCase message indicating details
-                about why the diagnosis is in this state.
-              type: string
-            recoverable:
-              description: Recoverable indicates if the diagnosis could be recovered
-                by the recoverer chain.
-              type: boolean
-            recoverer:
-              description: Recoverer indicates the recoverer which has recovered the
-                diagnosis successfully.
-              properties:
-                name:
-                  description: Name specifies the name of a kubernetes api resource.
-                  type: string
-                namespace:
-                  description: Namespace specifies the namespace of a kubernetes api
-                    resource.
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
             startTime:
               description: StartTime is RFC 3339 date and time at which the object
                 was acknowledged by the system.
               format: date-time
               type: string
-          required:
-          - identifiable
-          - recoverable
           type: object
       type: object
   version: v1

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -556,29 +556,6 @@ spec:
                 to be user-facing content and display instructions. This field may
                 contain customized values for custom source.
               type: object
-            diagnoser:
-              description: Diagnoser indicates the diagnoser which has identified
-                the diagnosis successfully.
-              properties:
-                name:
-                  description: Name specifies the name of a kubernetes api resource.
-                  type: string
-                namespace:
-                  description: Namespace specifies the namespace of a kubernetes api
-                    resource.
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
-            identifiable:
-              description: Identifiable indicates if the diagnosis could be identified
-                by the diagnoser chain.
-              type: boolean
-            message:
-              description: Message is a human readable message indicating details
-                about why the diagnosis is in this condition.
-              type: string
             phase:
               description: "Phase is a simple, high-level summary of where the diagnosis
                 is in its lifecycle. The conditions array, the reason and message
@@ -624,37 +601,11 @@ spec:
                 - type
                 type: object
               type: array
-            reason:
-              description: Reason is a brief CamelCase message indicating details
-                about why the diagnosis is in this state.
-              type: string
-            recoverable:
-              description: Recoverable indicates if the diagnosis could be recovered
-                by the recoverer chain.
-              type: boolean
-            recoverer:
-              description: Recoverer indicates the recoverer which has recovered the
-                diagnosis successfully.
-              properties:
-                name:
-                  description: Name specifies the name of a kubernetes api resource.
-                  type: string
-                namespace:
-                  description: Namespace specifies the namespace of a kubernetes api
-                    resource.
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
             startTime:
               description: StartTime is RFC 3339 date and time at which the object
                 was acknowledged by the system.
               format: date-time
               type: string
-          required:
-          - identifiable
-          - recoverable
           type: object
       type: object
   version: v1

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -443,32 +443,14 @@ func ValidateDiagnosisResult(result diagnosisv1.Diagnosis, current diagnosisv1.D
 	if !reflect.DeepEqual(result.Spec, current.Spec) {
 		return fmt.Errorf("spec field of Diagnosis must not be modified")
 	}
-	if !reflect.DeepEqual(result.Status.Identifiable, current.Status.Identifiable) {
-		return fmt.Errorf("identifiable field of Diagnosis must not be modified")
-	}
-	if !reflect.DeepEqual(result.Status.Recoverable, current.Status.Recoverable) {
-		return fmt.Errorf("recoverable field of Diagnosis must not be modified")
-	}
 	if !reflect.DeepEqual(result.Status.Phase, current.Status.Phase) {
 		return fmt.Errorf("phase field of Diagnosis must not be modified")
 	}
 	if !reflect.DeepEqual(result.Status.Conditions, current.Status.Conditions) {
 		return fmt.Errorf("conditions field of Diagnosis must not be modified")
 	}
-	if !reflect.DeepEqual(result.Status.Message, current.Status.Message) {
-		return fmt.Errorf("message field of Diagnosis must not be modified")
-	}
-	if !reflect.DeepEqual(result.Status.Reason, current.Status.Reason) {
-		return fmt.Errorf("reason field of Diagnosis must not be modified")
-	}
 	if !reflect.DeepEqual(result.Status.StartTime, current.Status.StartTime) {
 		return fmt.Errorf("startTime field of Diagnosis must not be modified")
-	}
-	if !reflect.DeepEqual(result.Status.Diagnoser, current.Status.Diagnoser) {
-		return fmt.Errorf("diagnoser field of Diagnosis must not be modified")
-	}
-	if !reflect.DeepEqual(result.Status.Recoverer, current.Status.Recoverer) {
-		return fmt.Errorf("recoverer field of Diagnosis must not be modified")
 	}
 
 	return nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -916,9 +916,7 @@ func TestValidateDiagnosisResult(t *testing.T) {
 			},
 		},
 		Status: diagnosisv1.DiagnosisStatus{
-			Identifiable: false,
-			Recoverable:  false,
-			Phase:        diagnosisv1.DiagnosisDiagnosing,
+			Phase: diagnosisv1.DiagnosisDiagnosing,
 			Conditions: []diagnosisv1.DiagnosisCondition{
 				{
 					Type:    diagnosisv1.InformationCollected,
@@ -928,21 +926,11 @@ func TestValidateDiagnosisResult(t *testing.T) {
 				},
 			},
 			StartTime: metav1.NewTime(time),
-			Diagnoser: &diagnosisv1.NamespacedName{
-				Namespace: "default",
-				Name:      "diagnoser1",
-			},
 		},
 	}
 
 	invalidSpec := diagnosis
 	invalidSpec.Spec.Source = "KubernetesEvent"
-
-	invalidIdentifiable := diagnosis
-	invalidIdentifiable.Status.Identifiable = true
-
-	invalidRecoverable := diagnosis
-	invalidRecoverable.Status.Recoverable = true
 
 	invalidPhase := diagnosis
 	invalidPhase.Status.Phase = diagnosisv1.DiagnosisFailed
@@ -950,26 +938,8 @@ func TestValidateDiagnosisResult(t *testing.T) {
 	invalidConditions := diagnosis
 	invalidConditions.Status.Conditions = []diagnosisv1.DiagnosisCondition{}
 
-	invalidMessage := diagnosis
-	invalidMessage.Status.Message = "message"
-
-	invalidReason := diagnosis
-	invalidReason.Status.Reason = "reason"
-
 	invalidStartTime := diagnosis
 	invalidStartTime.Status.StartTime = metav1.NewTime(time.Add(1000))
-
-	invalidDiagnoser := diagnosis
-	invalidDiagnoser.Status.Diagnoser = &diagnosisv1.NamespacedName{
-		Namespace: "default",
-		Name:      "diagnoser2",
-	}
-
-	invalidRecoverer := diagnosis
-	invalidRecoverer.Status.Recoverer = &diagnosisv1.NamespacedName{
-		Namespace: "default",
-		Name:      "recoverer1",
-	}
 
 	valid := diagnosis
 	valid.Status.Context = &runtime.RawExtension{
@@ -1008,18 +978,6 @@ func TestValidateDiagnosisResult(t *testing.T) {
 		},
 		{
 			current:  diagnosis,
-			result:   invalidIdentifiable,
-			expected: fmt.Errorf("identifiable field of Diagnosis must not be modified"),
-			desc:     "invalid identifiable field",
-		},
-		{
-			current:  diagnosis,
-			result:   invalidRecoverable,
-			expected: fmt.Errorf("recoverable field of Diagnosis must not be modified"),
-			desc:     "invalid recoverable field",
-		},
-		{
-			current:  diagnosis,
 			result:   invalidPhase,
 			expected: fmt.Errorf("phase field of Diagnosis must not be modified"),
 			desc:     "invalid phase field",
@@ -1032,33 +990,9 @@ func TestValidateDiagnosisResult(t *testing.T) {
 		},
 		{
 			current:  diagnosis,
-			result:   invalidMessage,
-			expected: fmt.Errorf("message field of Diagnosis must not be modified"),
-			desc:     "invalid message field",
-		},
-		{
-			current:  diagnosis,
-			result:   invalidReason,
-			expected: fmt.Errorf("reason field of Diagnosis must not be modified"),
-			desc:     "invalid reason field",
-		},
-		{
-			current:  diagnosis,
 			result:   invalidStartTime,
 			expected: fmt.Errorf("startTime field of Diagnosis must not be modified"),
 			desc:     "invalid startTime field",
-		},
-		{
-			current:  diagnosis,
-			result:   invalidDiagnoser,
-			expected: fmt.Errorf("diagnoser field of Diagnosis must not be modified"),
-			desc:     "invalid diagnoser field",
-		},
-		{
-			current:  diagnosis,
-			result:   invalidRecoverer,
-			expected: fmt.Errorf("recoverer field of Diagnosis must not be modified"),
-			desc:     "invalid recoverer field",
 		},
 	}
 


### PR DESCRIPTION
This pull request removes the following unused APIs in Diagnosis:

* `.status.identifiable`
* `.status.recoverable`
* `.status.message`
* `.status.reason`
* `.status.diagnoser`
* `.status.recoverer`