### PR TITLE
Fix typo in kubebuilder resource scope annotation of graph CRDs

### DIFF
--- a/api/v1/operation_types.go
+++ b/api/v1/operation_types.go
@@ -70,7 +70,7 @@ type HostPath struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=cluster
+// +kubebuilder:resource:scope=Cluster
 
 // Operation is the Schema for the operations API.
 type Operation struct {

--- a/api/v1/operationset_types.go
+++ b/api/v1/operationset_types.go
@@ -57,7 +57,7 @@ type OperationSetStatus struct {
 type TopologicalSort []Node
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=cluster
+// +kubebuilder:resource:scope=Cluster
 
 // OperationSet is the Schema for the operationsets API.
 type OperationSet struct {

--- a/api/v1/trigger_types.go
+++ b/api/v1/trigger_types.go
@@ -110,7 +110,7 @@ type TriggerStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=cluster
+// +kubebuilder:resource:scope=Cluster
 
 // Trigger is the Schema for the triggers API.
 type Trigger struct {

--- a/config/crd/bases/diagnosis.netease.com_operations.yaml
+++ b/config/crd/bases/diagnosis.netease.com_operations.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: OperationList
     plural: operations
     singular: operation
-  scope: cluster
+  scope: Cluster
   validation:
     openAPIV3Schema:
       description: Operation is the Schema for the operations API.

--- a/config/crd/bases/diagnosis.netease.com_operationsets.yaml
+++ b/config/crd/bases/diagnosis.netease.com_operationsets.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: OperationSetList
     plural: operationsets
     singular: operationset
-  scope: cluster
+  scope: Cluster
   validation:
     openAPIV3Schema:
       description: OperationSet is the Schema for the operationsets API.

--- a/config/crd/bases/diagnosis.netease.com_triggers.yaml
+++ b/config/crd/bases/diagnosis.netease.com_triggers.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: TriggerList
     plural: triggers
     singular: trigger
-  scope: cluster
+  scope: Cluster
   validation:
     openAPIV3Schema:
       description: Trigger is the Schema for the triggers API.


### PR DESCRIPTION
kubebuilder common of  some types (operation , operationset , trigger) doesn't have right capitalization.  

`make install`  (env version: v1.11.1) will failed with :

```
...
customresourcedefinition.apiextensions.k8s.io/recoverers.diagnosis.netease.com configured
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "operations.diagnosis.netease.com" is invalid: spec.scope: Unsupported value: "cluster": supported values: "Cluster", "Namespaced"
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "operationsets.diagnosis.netease.com" is invalid: spec.scope: Unsupported value: "cluster": supported values: "Cluster", "Namespaced"
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "triggers.diagnosis.netease.com" is invalid: spec.scope: Unsupported value: "cluster": supported values: "Cluster", "Namespaced"
Makefile:33: recipe for target 'install' failed

```