### PR TITLE
Fix circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
       - run:
           name: Run unit tests
           command: |
+            curl -sLo /tmp/kustomize_v4.0.5_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.0.5/kustomize_v4.0.5_linux_amd64.tar.gz
+            sudo tar -C /usr/local/bin -xzf /tmp/kustomize_v4.0.5_linux_amd64.tar.gz
             make test
       # run e2e test
       - run:

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,6 @@ TAG ?= $(shell git rev-parse --short HEAD)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
-# Use local kustomize (version v4.0.5)
-MKFILE_PATH = $(abspath $(lastword $(MAKEFILE_LIST)))
-MKFILE_DIR = $(dir $(MKFILE_PATH))
-KUSTOMIZE = "$(MKFILE_DIR)tools/kustomize"
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
Circleci running always failed after kustomize is deleted, this pull request add its installation in config file.
#41 