### PR TITLE
Stop reporting error if the profiler data directory does not exist

### DIFF
--- a/pkg/diagnosisreaper/diagnosisreaper.go
+++ b/pkg/diagnosisreaper/diagnosisreaper.go
@@ -19,6 +19,7 @@ package diagnosisreaper
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -216,6 +217,12 @@ func (dr *DiagnosisReaper) listDiagnoses() ([]diagnosisv1.Diagnosis, error) {
 // DeleteExpiredProfilerData deletes profiler data by removing files or directories if the file age is longer
 // than diagnosisTTL.
 func DeleteExpiredProfilerData(path string, diagnosisTTL time.Duration, log logr.Logger) error {
+	// Return if the profiler data directory does not exist.
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
This patch stops reporting the following error if the profiler data directory does not exist during garbage collection:

```
2021-12-27T10:08:13.191Z        ERROR   diagnosisreaper failed to garbage collect java profiler data    {"error": "open /var/lib/kubediag/profilers/java/memory: no such file or directory"}
github.com/go-logr/zapr.(*zapLogger).Error
        /workspace/vendor/github.com/go-logr/zapr/zapr.go:128
github.com/kubediag/kubediag/pkg/diagnosisreaper.(*DiagnosisReaper).Run.func1
        /workspace/pkg/diagnosisreaper/diagnosisreaper.go:191
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
2021-12-27T10:08:13.191Z        INFO    controller-runtime.controller   Starting workers        {"controller": "diagnosis", "worker count": 1}
2021-12-27T10:08:13.191Z        ERROR   diagnosisreaper failed to garbage collect go profiler data      {"error": "open /var/lib/kubediag/profilers/go/pprof: no such file or directory"}
github.com/go-logr/zapr.(*zapLogger).Error
        /workspace/vendor/github.com/go-logr/zapr/zapr.go:128
github.com/kubediag/kubediag/pkg/diagnosisreaper.(*DiagnosisReaper).Run.func1
        /workspace/pkg/diagnosisreaper/diagnosisreaper.go:198
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
        /workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
```