### PR TITLE
Remove dependency of Cert-Manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
             kubectl apply -f config/deploy/manifests.yaml
             kubectl --namespace kubediag wait --for=condition=ready  --timeout=600s pod -l mode=agent
             kubectl --namespace kubediag wait --for=condition=ready  --timeout=600s pod -l mode=master
+            sleep 10
             # wait for webhook service ready
             for (( c=1; c<=5; c++ )); do if( kubectl apply -f config/deploy/ ); then break ;fi ;sleep 10; done
             make e2e

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,9 +20,11 @@ bases:
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
+#- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
 - ../prometheus
+# [CERTGEN] To enable kube-webhook-certgen
+- ../kubewebhookcertgen
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
@@ -37,25 +39,25 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+#- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
+# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: CERTIFICATE_NAME
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:
     kind: Service

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -983,6 +983,27 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubediag-webhook-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election-rolebinding
@@ -1017,6 +1038,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kubediag-role
+subjects:
+- kind: ServiceAccount
+  name: kubediag
+  namespace: kubediag
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubediag-webhook-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubediag-webhook-role
 subjects:
 - kind: ServiceAccount
   name: kubediag
@@ -1081,7 +1115,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: webhook-service
+  name: kubediag-webhook-service
   namespace: kubediag
 spec:
   ports:
@@ -1277,27 +1311,74 @@ spec:
       maxUnavailable: 5
     type: RollingUpdate
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: serving-cert
+  name: kubediag-admission-create
   namespace: kubediag
 spec:
-  dnsNames:
-  - webhook-service.kubediag.svc
-  - webhook-service.kubediag.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: webhook-server-cert
+  template:
+    metadata:
+      name: kubediag-admission-create
+    spec:
+      containers:
+      - args:
+        - create
+        - --cert-name=tls.crt
+        - --key-name=tls.key
+        - --host=,kubediag-webhook-service.kubediag.svc
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        name: create
+        resources: {}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      serviceAccountName: kubediag
 ---
-apiVersion: cert-manager.io/v1
-kind: Issuer
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: selfsigned-issuer
+  name: kubediag-admission-patch
   namespace: kubediag
 spec:
-  selfSigned: {}
+  template:
+    metadata:
+      name: kubediag-admission-patch
+    spec:
+      containers:
+      - args:
+        - patch
+        - --webhook-name=kubediag-mutating-webhook-configuration
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        - --patch-failure-policy=Fail
+        - --patch-mutating=true
+        - --patch-validating=false
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        name: patch-mutating-webhook
+        resources: {}
+      - args:
+        - patch
+        - --webhook-name=kubediag-validating-webhook-configuration
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        - --patch-failure-policy=Fail
+        - --patch-mutating=false
+        - --patch-validating=true
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        name: patch-validating-webhook
+        resources: {}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      serviceAccountName: kubediag
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1342,14 +1423,13 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: kubediag/serving-cert
-  name: mutating-webhook-configuration
+  creationTimestamp: null
+  name: kubediag-mutating-webhook-configuration
 webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /mutate-diagnosis-kubediag-org-v1-diagnosis
   failurePolicy: Fail
@@ -1367,7 +1447,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /mutate-diagnosis-kubediag-org-v1-operation
   failurePolicy: Fail
@@ -1385,7 +1465,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /mutate-diagnosis-kubediag-org-v1-operationset
   failurePolicy: Fail
@@ -1403,7 +1483,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /mutate-diagnosis-kubediag-org-v1-trigger
   failurePolicy: Fail
@@ -1422,14 +1502,13 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: kubediag/serving-cert
-  name: validating-webhook-configuration
+  creationTimestamp: null
+  name: kubediag-validating-webhook-configuration
 webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /validate-diagnosis-kubediag-org-v1-diagnosis
   failurePolicy: Fail
@@ -1447,7 +1526,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /validate-diagnosis-kubediag-org-v1-operation
   failurePolicy: Fail
@@ -1465,7 +1544,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /validate-diagnosis-kubediag-org-v1-operationset
   failurePolicy: Fail
@@ -1483,7 +1562,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: kubediag-webhook-service
       namespace: kubediag
       path: /validate-diagnosis-kubediag-org-v1-trigger
   failurePolicy: Fail

--- a/config/kubewebhookcertgen/job-create-secret.yaml
+++ b/config/kubewebhookcertgen/job-create-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubediag-admission-create
+  namespace: kubediag
+spec:
+  template:
+    metadata:
+      name: kubediag-admission-create
+    spec:
+      containers:
+      - name: create
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - create
+        - --cert-name=tls.crt
+        - --key-name=tls.key
+        - --host=,$(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        resources: {}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      serviceAccountName: kubediag 

--- a/config/kubewebhookcertgen/job-patch-webhook.yaml
+++ b/config/kubewebhookcertgen/job-patch-webhook.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubediag-admission-patch
+  namespace: kubediag
+spec:
+  template:
+    metadata:
+      name: kubediag-admission-patch
+    spec:
+      containers:
+      - name: patch-mutating-webhook
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - patch
+        - --webhook-name=kubediag-mutating-webhook-configuration
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        - --patch-failure-policy=Fail
+        - --patch-mutating=true
+        - --patch-validating=false
+        resources: {}
+      - name: patch-validating-webhook
+        image: jettech/kube-webhook-certgen:v1.5.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - patch
+        - --webhook-name=kubediag-validating-webhook-configuration
+        - --namespace=kubediag
+        - --secret-name=webhook-server-cert
+        - --patch-failure-policy=Fail
+        - --patch-mutating=false
+        - --patch-validating=true
+        resources: {}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      serviceAccountName: kubediag

--- a/config/kubewebhookcertgen/kustomization.yaml
+++ b/config/kubewebhookcertgen/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- job-create-secret.yaml
+- job-patch-webhook.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
 - apiserver_profiler_viewer_clusterrole.yaml
 - apiserver_profiler_viewer_serviceaccount.yaml
 - apiserver_profiler_viewer_binding.yaml
+- webhook_role.yaml
+- webhook_role_binding.yaml

--- a/config/rbac/webhook_role.yaml
+++ b/config/rbac/webhook_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubediag-webhook-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - update

--- a/config/rbac/webhook_role_binding.yaml
+++ b/config/rbac/webhook_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubediag-webhook-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubediag-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: kubediag
+  namespace: kubediag

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - manifests.yaml
 - service.yaml
-
+namePrefix:  kubediag-
 configurations:
 - kustomizeconfig.yaml


### PR DESCRIPTION
It is inappropriate to install cert-manager before installing KubeDiag. 
Use a light weight image kube-webhook-certgen( instead of cert-manager )to:

* create a ca, server cert+key and store the results in a secret;
* patch  validatingwebhookconfiguration and mutatingwebhookconfiguration by using the ca.

And the name of MutatingWebhookConfiguration & ValidatingWebhookConfiguration & WebhookService is updated with prefix "kubediag-".