### PR TITLE
Fix diagnosis run repeatedly

### DIFF
--- a/pkg/controllers/diagnosis_controller.go
+++ b/pkg/controllers/diagnosis_controller.go
@@ -237,11 +237,6 @@ func (r *DiagnosisReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 
-			err := util.QueueDiagnosis(ctx, r.executorCh, diagnosis)
-			if err != nil {
-				log.Error(err, "failed to send diagnosis to executor queue")
-			}
-			diagnosisAgentQueuedCount.Inc()
 		case diagnosisv1.DiagnosisRunning:
 			err := util.QueueDiagnosis(ctx, r.executorCh, diagnosis)
 			if err != nil {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -319,7 +319,8 @@ func (ex *executor) syncDiagnosis(diagnosis diagnosisv1.Diagnosis) (diagnosisv1.
 			return diagnosis, fmt.Errorf("unable to update Diagnosis: %s", err)
 		}
 
-		return diagnosis, fmt.Errorf("hash value of adjacency list calculated")
+		ex.Info("hash value of adjacency list calculated")
+		return diagnosis, nil
 	}
 
 	// Validate the graph defined by operation set is not changed.


### PR DESCRIPTION
This merge request fix diagnosis hash value of adjacency list, no error will return at initialization. 
Fix #115 