### PR TITLE
Add parameters in alertmanager trigger

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -269,6 +269,9 @@ func (am *alertmanager) createDiagnosisFromPrometheusAlert(triggers []diagnosisv
 				}
 
 				parameters := make(map[string]string)
+				for key, value := range trigger.Spec.Parameters {
+					parameters[key] = value
+				}
 				for _, label := range sourceTemplate.PrometheusAlertTemplate.ParameterInjectionLabels {
 					value, ok := alert.Labels[label]
 					if ok {


### PR DESCRIPTION
This patch updates alertmanger trigger to transfer parameters in `trigger.spec` to new prometheus alertmanager diagnosis.
Linked issue: https://github.com/kubediag/kubediag/issues/114