### PR TITLE
Set the latest tag enviroment in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: Verify code
           command: |
-            export TAG=v0.2.2
+            export TAG=$(git describe --tags --abbrev=0)
             make fmt && make vet && go mod vendor && go mod tidy && make manifests
             if [ -n "$(git diff --name-only)" ] ; then exit 1; fi
       - run:


### PR DESCRIPTION
This pull request sets latest tag enviroment in CircleCI build on verifying code.