### PR TITLE
Fix CircleCI release image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
   build_and_push:
     environment:
       DOCKER_REGISTRY: hub.c.163.com
-      REPO_NAME: hub.c.163.com/kubediag/ci-test
+      REPO_NAME: hub.c.163.com/kubediag/kubediag
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:


### PR DESCRIPTION
This pull request update `REPO_NAME` environment variable to `hub.c.163.com/kubediag/kubediag` in release pipeline.