### PR TITLE
Create a CommonEvent according to a received Prometheus alert

### DIFF
--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -1257,6 +1257,7 @@ spec:
         - --port=8089
         - --metrics-port=10357
         - --enable-leader-election=true
+        - --repeat-interval=5m
         command:
         - /kubediag
         env:

--- a/config/manager/kubediag.yaml
+++ b/config/manager/kubediag.yaml
@@ -31,7 +31,8 @@ spec:
         - --port=8089
         - --metrics-port=10357
         - --enable-leader-election=true
-        image: hub.c.163.com/kubediag/kubediag:v0.2.2
+        - --repeat-interval=5m
+        image: hub.c.163.com/kubediag/kubediag:v0.3.0
         env:
         - name: POD_IP
           valueFrom:

--- a/pkg/alertmanager/alert.go
+++ b/pkg/alertmanager/alert.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The KubeDiag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alertmanager
+
+import (
+	"github.com/prometheus/alertmanager/types"
+)
+
+const (
+	// SummaryLabel is the name of the label containing the an alert's summary.
+	SummaryLabel = "summary"
+	// DescriptionLabel is the name of the label containing the an alert's description.
+	DescriptionLabel = "description"
+	// SourceLabel is the name of the label containing the an alert's source.
+	SourceLabel = "source"
+	// SeverityLabel is the name of the label containing the an alert's severity.
+	SeverityLabel = "severity"
+	// ComponentLabel is the name of the label containing the an alert's component.
+	ComponentLabel = "component"
+	// GroupLabel is the name of the label containing the an alert's group.
+	GroupLabel = "group"
+)
+
+type Alert types.Alert
+
+// Summary returns the summary of the alert. It is equivalent to the "summary" label.
+func (a *Alert) Summary() string {
+	return string(a.Annotations[SummaryLabel])
+}
+
+// Description returns the description of the alert. It is equivalent to the "description" label.
+func (a *Alert) Description() string {
+	return string(a.Annotations[DescriptionLabel])
+}
+
+// Source returns the source of the alert. It is equivalent to the "source" label.
+func (a *Alert) Source() string {
+	return string(a.Labels[SourceLabel])
+}
+
+// Severity returns the severity of the alert. It is equivalent to the "severity" label.
+func (a *Alert) Severity() string {
+	return string(a.Labels[SeverityLabel])
+}
+
+// Component returns the component of the alert. It is equivalent to the "component" label.
+func (a *Alert) Component() string {
+	return string(a.Labels[ComponentLabel])
+}
+
+// Group returns the group of the alert. It is equivalent to the "group" label.
+func (a *Alert) Group() string {
+	return string(a.Labels[GroupLabel])
+}


### PR DESCRIPTION
This pull requests implements logic to create a common event according to a received prometheus alert in the alertmanager handler.