### PR TITLE
fix the empty state of diagnosis

### DIFF
--- a/pkg/controllers/diagnosis_controller.go
+++ b/pkg/controllers/diagnosis_controller.go
@@ -185,6 +185,14 @@ func (r *DiagnosisReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 					Namespace: diagnosis.Spec.PodReference.Namespace,
 				}, &pod); err != nil {
 					log.Error(err, "unable to fetch Pod")
+
+					diagnosis.Status.StartTime = metav1.Now()
+					diagnosis.Status.Phase = diagnosisv1.DiagnosisPending
+					if err := r.Status().Update(ctx, &diagnosis); err != nil {
+						log.Error(err, "unable to update Diagnosis")
+						return ctrl.Result{}, client.IgnoreNotFound(err)
+					}
+
 					return ctrl.Result{}, client.IgnoreNotFound(err)
 				}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -276,9 +276,9 @@ func IsDiagnosisCompleted(diagnosis diagnosisv1.Diagnosis) bool {
 }
 
 // IsDiagnosisNodeNameMatched checks if the diagnosis is on the specific node.
-// It returns true if node name of the diagnosis is empty or matches provided node name, otherwise false.
+// It returns true if current node name of the diagnosis matches provided NodeName field or the NodeName based on podReference field.
 func IsDiagnosisNodeNameMatched(diagnosis diagnosisv1.Diagnosis, nodeName string) bool {
-	return diagnosis.Spec.NodeName == "" || diagnosis.Spec.NodeName == nodeName
+	return diagnosis.Spec.NodeName == nodeName
 }
 
 // RetrievePodsOnNode retrieves all pods on the provided node.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -426,7 +426,7 @@ func TestIsDiagnosisNodeNameMatched(t *testing.T) {
 				},
 			},
 			node:     "node1",
-			expected: true,
+			expected: false,
 			desc:     "empty node name",
 		},
 		{


### PR DESCRIPTION
This merge request fix empty phase of diagnosis problem. It happened when diagnosis cannot determine the node to be scheduled since podReference is specified incorrectly. #168 