### PR TITLE
Fix nil reference issue when diagnosis parameter is not empty

### DIFF
--- a/pkg/controllers/diagnosis_controller.go
+++ b/pkg/controllers/diagnosis_controller.go
@@ -252,9 +252,6 @@ func (r *DiagnosisReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 		diagnosis.Status.Phase = diagnosisv1.DiagnosisRunning
 		diagnosis.Status.NodeNames = nodeNames
-		if diagnosis.Spec.Parameters != nil {
-			diagnosis.Status.Context.Parameters = diagnosis.Spec.Parameters
-		}
 		if err := r.Status().Update(ctx, &diagnosis); err != nil {
 			log.Error(err, "unable to update Diagnosis")
 			return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/processors/collector/container_collector.go
+++ b/pkg/processors/collector/container_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/containerd_goroutine_collector.go
+++ b/pkg/processors/collector/containerd_goroutine_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/docker_info_collector.go
+++ b/pkg/processors/collector/docker_info_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/dockerd_goroutine_collector.go
+++ b/pkg/processors/collector/dockerd_goroutine_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/elasticsearch_collector.go
+++ b/pkg/processors/collector/elasticsearch_collector.go
@@ -1,4 +1,20 @@
-package log
+/*
+Copyright 2022 The KubeDiag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
 
 import (
 	"bytes"

--- a/pkg/processors/collector/mountinfo_collector.go
+++ b/pkg/processors/collector/mountinfo_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package system
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/pod_detail_collector.go
+++ b/pkg/processors/collector/pod_detail_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/pod_list_collector.go
+++ b/pkg/processors/collector/pod_list_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/process_collector.go
+++ b/pkg/processors/collector/process_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package system
+package collector
 
 import (
 	"context"

--- a/pkg/processors/collector/statefulset_detail_collector.go
+++ b/pkg/processors/collector/statefulset_detail_collector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package collector
 
 import (
 	"context"

--- a/pkg/processors/diagnoser/corefile_profiler.go
+++ b/pkg/processors/diagnoser/corefile_profiler.go
@@ -1,4 +1,20 @@
-package runtime
+/*
+Copyright 2021 The KubeDiag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnoser
 
 import (
 	"context"

--- a/pkg/processors/diagnoser/go_profiler.go
+++ b/pkg/processors/diagnoser/go_profiler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package diagnoser
 
 import (
 	"bytes"

--- a/pkg/processors/diagnoser/subpath_remount_diagnoser.go
+++ b/pkg/processors/diagnoser/subpath_remount_diagnoser.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package diagnoser
 
 import (
 	"context"
@@ -29,8 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/kubediag/kubediag/pkg/processors"
-	"github.com/kubediag/kubediag/pkg/processors/collector/kubernetes"
-	"github.com/kubediag/kubediag/pkg/processors/collector/system"
+	"github.com/kubediag/kubediag/pkg/processors/collector"
 	"github.com/kubediag/kubediag/pkg/processors/utils"
 )
 
@@ -87,13 +86,13 @@ func (srd *subPathRemountDiagnoser) Handler(w http.ResponseWriter, r *http.Reque
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if contexts[kubernetes.ContextKeyPodDetail] == "" || contexts[system.ContextKeyMountInfo] == "" {
-			srd.Error(err, fmt.Sprintf("need %s and %s in extract contexts", kubernetes.ContextKeyPodDetail, system.ContextKeyMountInfo))
+		if contexts[collector.ContextKeyPodDetail] == "" || contexts[collector.ContextKeyMountInfo] == "" {
+			srd.Error(err, fmt.Sprintf("need %s and %s in extract contexts", collector.ContextKeyPodDetail, collector.ContextKeyMountInfo))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		pod := corev1.Pod{}
-		err = json.Unmarshal([]byte(contexts[kubernetes.ContextKeyPodDetail]), &pod)
+		err = json.Unmarshal([]byte(contexts[collector.ContextKeyPodDetail]), &pod)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to unmarshal pod: %v", err), http.StatusInternalServerError)
 			return
@@ -160,7 +159,7 @@ func (srd *subPathRemountDiagnoser) Handler(w http.ResponseWriter, r *http.Reque
 		}
 		srd.Info("get mount source path", "path", sourcePath)
 
-		mountInfos := strings.Split(contexts[system.ContextKeyMountInfo], "\n")
+		mountInfos := strings.Split(contexts[collector.ContextKeyMountInfo], "\n")
 		var mountLine string
 		for _, line := range mountInfos {
 			if strings.Contains(line, sourcePath) {

--- a/pkg/processors/diagnoser/tcpdump_profiler.go
+++ b/pkg/processors/diagnoser/tcpdump_profiler.go
@@ -1,4 +1,20 @@
-package runtime
+/*
+Copyright 2022 The KubeDiag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnoser
 
 import (
 	"context"

--- a/pkg/processors/recoverer/node_cordon.go
+++ b/pkg/processors/recoverer/node_cordon.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package recoverer
 
 import (
 	"context"

--- a/pkg/processors/recoverer/statefulset_stuck.go
+++ b/pkg/processors/recoverer/statefulset_stuck.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package recoverer
 
 import (
 	"context"
@@ -28,8 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubediag/kubediag/pkg/processors"
-	"github.com/kubediag/kubediag/pkg/processors/collector/kubernetes"
-	"github.com/kubediag/kubediag/pkg/processors/collector/system"
+	"github.com/kubediag/kubediag/pkg/processors/collector"
 	"github.com/kubediag/kubediag/pkg/processors/utils"
 )
 
@@ -84,26 +83,26 @@ func (ss *StatefuSetStuck) Handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Get StatefuSet info
-		if contexts[kubernetes.ContextKeyStatefuSetDetailResult] == "" {
-			ss.Error(err, fmt.Sprintf("need %s and %s in extract contexts", kubernetes.ContextKeyPodDetail, system.ContextKeyMountInfo))
+		if contexts[collector.ContextKeyStatefuSetDetailResult] == "" {
+			ss.Error(err, fmt.Sprintf("need %s and %s in extract contexts", collector.ContextKeyPodDetail, collector.ContextKeyMountInfo))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		statefulset := appsv1.StatefulSet{}
-		err = json.Unmarshal([]byte(contexts[kubernetes.ContextKeyStatefuSetDetailResult]), &statefulset)
+		err = json.Unmarshal([]byte(contexts[collector.ContextKeyStatefuSetDetailResult]), &statefulset)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to unmarshal statefulset: %v", err), http.StatusInternalServerError)
 			return
 		}
 
 		// Get Pod Info
-		if contexts[kubernetes.ContextKeyPodDetail] == "" {
-			ss.Error(err, fmt.Sprintf("need %s in extract contexts", kubernetes.ContextKeyPodDetail))
+		if contexts[collector.ContextKeyPodDetail] == "" {
+			ss.Error(err, fmt.Sprintf("need %s in extract contexts", collector.ContextKeyPodDetail))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		pod := corev1.Pod{}
-		err = json.Unmarshal([]byte(contexts[kubernetes.ContextKeyPodDetail]), &pod)
+		err = json.Unmarshal([]byte(contexts[collector.ContextKeyPodDetail]), &pod)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to unmarshal pod: %v", err), http.StatusInternalServerError)
 			return

--- a/pkg/processors/recoverer/subpath_remount_recover.go
+++ b/pkg/processors/recoverer/subpath_remount_recover.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package recoverer
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/kubediag/kubediag/pkg/processors"
-	"github.com/kubediag/kubediag/pkg/processors/diagnoser/kubernetes"
+	"github.com/kubediag/kubediag/pkg/processors/diagnoser"
 	"github.com/kubediag/kubediag/pkg/processors/utils"
 )
 
@@ -73,7 +73,7 @@ func (srr *subPathRemountRecover) Handler(w http.ResponseWriter, r *http.Request
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		target := contexts[kubernetes.ContextKeySubpathRemountOriginalDestinationPath]
+		target := contexts[diagnoser.ContextKeySubpathRemountOriginalDestinationPath]
 		if target == "" {
 			srr.Error(err, "extract contexts lack of some value", "key", "diagnosis.kubernetes.bug.subpathremount.firstdestination")
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This pull request resolves the following panic when diagnosis parameter is not empty:

```
2023-02-28T14:52:29.831+0800    INFO    controllers.Diagnosis   diagnosis accepted by kubediag master   {"diagnosis": "default/process-collector", "diagnosis": {"namespace": "default", "name": "process-collector"}}
E0228 14:52:29.832767   25275 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 402 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x543a140, 0x65a3760})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0009c22a0})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x543a140, 0x65a3760})
        /opt/homebrew/Cellar/go/1.17/libexec/src/runtime/panic.go:1038 +0x215
github.com/kubediag/kubediag/pkg/controllers.(*DiagnosisReconciler).Reconcile(0xc000380be0, {{{0xc0005a5389, 0x7}, {0xc0007222d0, 0x11}}})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/pkg/controllers/diagnosis_controller.go:256 +0x3efe
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004c2000, {0x54934c0, 0xc0009c22a0})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x19c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004c2000)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xc5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(...)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0x0)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x67
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0006a6b40, 0x3b9aca00, 0x0, 0x1, 0xc0006a6de0)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0x11d
k8s.io/apimachinery/pkg/util/wait.Until(0x45639aa, 0xc0005d0000, 0x140)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x25
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x71e
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4edc79e]

goroutine 402 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0009c22a0})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0xd8
panic({0x543a140, 0x65a3760})
        /opt/homebrew/Cellar/go/1.17/libexec/src/runtime/panic.go:1038 +0x215
github.com/kubediag/kubediag/pkg/controllers.(*DiagnosisReconciler).Reconcile(0xc000380be0, {{{0xc0005a5389, 0x7}, {0xc0007222d0, 0x11}}})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/pkg/controllers/diagnosis_controller.go:256 +0x3efe
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004c2000, {0x54934c0, 0xc0009c22a0})
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x19c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004c2000)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xc5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(...)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0x0)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x67
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0006a6b40, 0x3b9aca00, 0x0, 0x1, 0xc0006a6de0)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0x11d
k8s.io/apimachinery/pkg/util/wait.Until(0x45639aa, 0xc0005d0000, 0x140)
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x25
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /Users/huangjiuyuan/Workspace/go/src/github.com/kubediag/kubediag/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x71e
```